### PR TITLE
Clear out database on each run

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -119,4 +119,5 @@ def scrape_mp(url)
   ScraperWiki.save_sqlite(%i(id term), data)
 end
 
+ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil
 scrape_list('http://parliament.gov.gy/about-parliament/parliamentarian')


### PR DESCRIPTION
We're doing this with all scrapers so that it becomes apparent when data is disappearing from upstream source.